### PR TITLE
Update event type in CI workflow to trigger build and push

### DIFF
--- a/.github/workflows/trigger_build_image.yml
+++ b/.github/workflows/trigger_build_image.yml
@@ -25,4 +25,4 @@ jobs:
             -H "Authorization: token $GITHUB_TOKEN" \
             -H "Accept: application/vnd.github.v3+json" \
             https://api.github.com/repos/wise-vision/wisevision.proj/dispatches \
-            -d '{"event_type": "trigger-build-and-push-image"}'
+            -d '{"event_type": "trigger-build-and-push"}'


### PR DESCRIPTION
This pull request makes a minor update to the workflow trigger in `.github/workflows/trigger_build_image.yml`. The event type sent to the repository dispatch API has been renamed for clarity and consistency.

* Changed the event type in the workflow dispatch payload from `"trigger-build-and-push-image"` to `"trigger-build-and-push"` in `.github/workflows/trigger_build_image.yml`.